### PR TITLE
Add currency format to remainder

### DIFF
--- a/ConselvaBudget/Areas/Spending/Pages/Expenses/ExpensePageModel.cs
+++ b/ConselvaBudget/Areas/Spending/Pages/Expenses/ExpensePageModel.cs
@@ -22,7 +22,7 @@ namespace ConselvaBudget.Areas.Spending.Pages.Expenses
                 .Select(b => new
                 {
                     b.Id,
-                    Name = $"{b.Activity.Name} - {b.AccountAssignment.DisplayName} ({b.Remainder})",
+                    Name = $"{b.Activity.Name} - {b.AccountAssignment.DisplayName} ({b.Remainder.ToString("c")})",
                     ActivityId = b.ActivityId,
                     Group = b.Activity.Result.Project.Name
                 });


### PR DESCRIPTION
Gets the culture-aware currency string representation using `ToString("c")`.