### PR TITLE
Run workflow on pull requests

### DIFF
--- a/.github/workflows/main_conselvanet(staging).yml
+++ b/.github/workflows/main_conselvanet(staging).yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     branches:
       - main
   workflow_dispatch:

--- a/.github/workflows/main_conselvanet(staging).yml
+++ b/.github/workflows/main_conselvanet(staging).yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main_conselvanet(staging).yml
+++ b/.github/workflows/main_conselvanet(staging).yml
@@ -52,6 +52,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build-and-test
+    if: github.ref == 'refs/heads/main'
     environment:
       name: 'staging'
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}


### PR DESCRIPTION
As part of the new branch protection rule to require status checks to pass before merging, we need to run the `build-and-test` job before a pull request can be closed for `main`. This PR modifies the workflow to run on this scenario.

- Adds a trigger so that the workflow runs on pull request events, the run status will now show on the pull request page when it completes.
- Adds a condition to the `deploy` job so that it only runs in the `main` branch. i.e. when the `main` branch has been updated. This prevents the code from being deployed from the pull request itself before its merged, for example.