### PR TITLE
Don't run workflow checks on draft PRs

### DIFF
--- a/.github/workflows/main_conselvanet(staging).yml
+++ b/.github/workflows/main_conselvanet(staging).yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main_conselvanet(staging).yml
+++ b/.github/workflows/main_conselvanet(staging).yml
@@ -8,7 +8,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
- Don't run CI on [draft PRs](https://github.blog/2019-02-14-introducing-draft-pull-requests/) as by definition the code is not yet ready.
- Run when a PR changes [from draft to ready for review.](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)