### PR TITLE
Fix Remainder logic for Activity Budgets

### DIFF
--- a/ConselvaBudget/Areas/Budget/Pages/Projects/Manage.cshtml
+++ b/ConselvaBudget/Areas/Budget/Pages/Projects/Manage.cshtml
@@ -153,7 +153,7 @@
                                                         @Html.DisplayNameFor(model => activity.ActivityBudgets.ToList()[0].TotalExpenses)
                                                     </th>
                                                     <th>
-                                                        @Html.DisplayNameFor(model => activity.ActivityBudgets.ToList()[0].Remainder)
+                                                        @Html.DisplayNameFor(model => activity.ActivityBudgets.ToList()[0].RemainingBudget)
                                                     </th>
                                                     <th style="width: 1px; white-space:nowrap;"></th>
                                                 </tr>
@@ -172,7 +172,7 @@
                                                             @Html.DisplayFor(modelItem => budget.TotalExpenses)
                                                         </td>
                                                         <td class="align-middle">
-                                                            <span class="@(budget.Remainder < 0 ? "text-danger" : "")">@Html.DisplayFor(modelItem => budget.Remainder)</span>
+                                                            <span class="@(budget.RemainingBudget < 0 ? "text-danger" : "")">@Html.DisplayFor(modelItem => budget.RemainingBudget)</span>
                                                         </td>
                                                         <td class="align-middle">
                                                             <div class="d-flex gap-1 justify-content-center">

--- a/ConselvaBudget/Areas/Budget/Pages/Projects/Manage.cshtml.cs
+++ b/ConselvaBudget/Areas/Budget/Pages/Projects/Manage.cshtml.cs
@@ -39,6 +39,7 @@ namespace ConselvaBudget.Areas.Budget.Pages.Projects
                 .ThenInclude(r => r.Activities)
                 .ThenInclude(a => a.ActivityBudgets)
                 .ThenInclude(b => b.ExpenseInvoices)
+                .ThenInclude(ei => ei.Request)
                 .FirstOrDefaultAsync(p => p.Id == id);
 
             if (project == null)

--- a/ConselvaBudget/Areas/Reporting/Pages/Balance/Index.cshtml.cs
+++ b/ConselvaBudget/Areas/Reporting/Pages/Balance/Index.cshtml.cs
@@ -25,6 +25,7 @@ namespace ConselvaBudget.Areas.Reporting.Pages.Balance
                     .Include(b => b.AccountAssignment.Organization)
                     .Include(b => b.AccountAssignment.Account)
                     .Include(b => b.ExpenseInvoices)
+                    .ThenInclude(ei => ei.Request)
                     .ToListAsync();
 
             // Map to report view model
@@ -50,7 +51,7 @@ namespace ConselvaBudget.Areas.Reporting.Pages.Balance
                     Comments = activityBudget.Comments,
                     Amount = activityBudget.Amount,
                     Expenses = activityBudget.TotalExpenses,
-                    Remainder = activityBudget.Remainder,
+                    Remainder = activityBudget.RemainingBudget,
                 });
             }
             return data;

--- a/ConselvaBudget/Areas/Spending/Pages/AmountRequests/AmountRequestPageModel.cs
+++ b/ConselvaBudget/Areas/Spending/Pages/AmountRequests/AmountRequestPageModel.cs
@@ -17,14 +17,17 @@ namespace ConselvaBudget.Areas.Spending.Pages.AmountRequests
                 .Include(b => b.Activity.Result.Project)
                 .Include(b => b.AccountAssignment.Account)
                 .Include(b => b.AccountAssignment.Organization)
+                .Include(b => b.ExpenseInvoices)
+                .ThenInclude(ei => ei.Request)
                 .OrderBy(b => b.Activity.Result.Project.Name)
+                .ThenBy(b => b.Activity.Code)
                 .ThenBy(b => b.AccountAssignment.Organization.Code)
                 .ThenBy(b => b.AccountAssignment.Account.Code)
                 .Where(b => b.ActivityId == activityId)
                 .Select(b => new
                 {
                     b.Id,
-                    Name = $"{b.Activity.Code} - {b.AccountAssignment.DisplayName} ({b.Remainder.ToString("c")})",
+                    Name = $"{b.Activity.Code} - {b.AccountAssignment.DisplayName} ({b.RemainingBudget.ToString("c")})",
                     Group = b.Activity.Result.Project.Name
                 });            
 

--- a/ConselvaBudget/Areas/Spending/Pages/ExpenseInvoices/ExpenseInvoicePageModel.cs
+++ b/ConselvaBudget/Areas/Spending/Pages/ExpenseInvoices/ExpenseInvoicePageModel.cs
@@ -17,14 +17,17 @@ namespace ConselvaBudget.Areas.Spending.Pages.ExpenseInvoices
                 .Include(b => b.Activity.Result.Project)
                 .Include(b => b.AccountAssignment.Account)
                 .Include(b => b.AccountAssignment.Organization)
+                .Include(b => b.ExpenseInvoices)
+                .ThenInclude(ei => ei.Request)
                 .OrderBy(b => b.Activity.Result.Project.Name)
+                .ThenBy(b => b.Activity.Code)
                 .ThenBy(b => b.AccountAssignment.Organization.Code)
                 .ThenBy(b => b.AccountAssignment.Account.Code)
                 .Where(b => b.ActivityId == activityId)
                 .Select(b => new
                 {
                     b.Id,
-                    Name = $"{b.Activity.Code} - {b.AccountAssignment.DisplayName} ({b.Remainder.ToString("c")})",
+                    Name = $"{b.Activity.Code} - {b.AccountAssignment.DisplayName} ({b.RemainingBudget.ToString("c")})",
                     Group = b.Activity.Result.Project.Name
                 });
 

--- a/ConselvaBudget/Models/Activity.cs
+++ b/ConselvaBudget/Models/Activity.cs
@@ -31,7 +31,7 @@ namespace ConselvaBudget.Models
         [Display(Name = "ACTIVITY_REMAINING_BUDGET")]
         [DataType(DataType.Currency)]
         [ValidateNever]
-        public decimal RemainingBudget => ActivityBudgets.Sum(e => e.Remainder);
+        public decimal RemainingBudget => TotalBudget - TotalExpenses;
 
         [Display(Name = "ACTIVITY_RESULT")]
         public Result Result { get; set; }

--- a/ConselvaBudget/Models/ActivityBudget.cs
+++ b/ConselvaBudget/Models/ActivityBudget.cs
@@ -30,12 +30,22 @@ namespace ConselvaBudget.Models
         [Display(Name = "ACTIVITY_BUDGET_TOTAL_EXPENSES")]
         [DataType(DataType.Currency)]
         [ValidateNever]
-        public decimal TotalExpenses => 0;
+        public decimal TotalExpenses
+        {
+            get
+            {
+                var completedInvoices = ExpenseInvoices
+                    .Where(ei => ei.Request.Status == RequestStatus.Completed)
+                    .Sum(ei => ei.InvoiceAmount);
+
+                return completedInvoices;
+            }
+        }
 
         [Display(Name = "ACTIVITY_BUDGET_REMAINDER")]
         [DataType(DataType.Currency)]
         [ValidateNever]
-        public decimal Remainder => Amount - TotalExpenses;
+        public decimal RemainingBudget => Amount - TotalExpenses;
 
         [Display(Name = "ACTIVITY_BUDGET_ACTIVITY")]
         [DeleteBehavior(DeleteBehavior.Restrict)]

--- a/ConselvaBudget/Models/Result.cs
+++ b/ConselvaBudget/Models/Result.cs
@@ -31,7 +31,7 @@ namespace ConselvaBudget.Models
         [Display(Name = "RESULT_REMAINING_BUDGET")]
         [DataType(DataType.Currency)]
         [ValidateNever]
-        public decimal RemainingBudget => Activities.Sum(e => e.RemainingBudget);
+        public decimal RemainingBudget => TotalBudget - TotalExpenses;
 
         [Display(Name = "RESULT_PROJECT")]
         public Project Project { get; set; }


### PR DESCRIPTION
- Implement the new expense logic where only the `ExpenseInvoices` whose `Request` is marked as completed are counted against the budget.
- Eager load the entities needed for the new expenses calculation where needed.
- Simplify `RemainingBudget` logic in `Result` and `Activity` for consistency with `Project`.
- Rename `Remainder` to `RemainingBudget` in `ActivityBudget` for consistency with the rest of the code.