### PR TITLE
Simplify CreateEditLayout

### DIFF
--- a/ConselvaBudget/Pages/Shared/_CreateEditLayout.cshtml
+++ b/ConselvaBudget/Pages/Shared/_CreateEditLayout.cshtml
@@ -5,35 +5,10 @@
 
 <h1 class="pb-2 border-bottom">@ViewData["Title"]</h1>
 
-@if (IsSectionDefined("FormInfo"))
-{
-    <div class="row g-4">
-        <div class="col-lg-5 order-lg-last">
-            <div class="alert alert-secondary d-flex" role="alert">
-                <div class="fs-4 me-3">
-                    <i class="bi bi-info-circle-fill"></i>
-                </div>
-                <div>
-                    @RenderSection("FormInfo", required: false)
-                    <hr>
-                </div>
-            </div>
-        </div>
-        <div class="col-lg-7">
-            @await RenderSectionAsync("PreForm", required: false)
-            <form method="post" class="row g-3">
-                @RenderBody()
-            </form>
-        </div>
-    </div>
-}
-else
-{
-    @await RenderSectionAsync("PreForm", required: false)
-    <form method="post" class="row g-3">
-        @RenderBody()
-    </form>
-}
+@await RenderSectionAsync("PreForm", required: false)
+<form method="post" class="row g-3">
+    @RenderBody()
+</form>
 
 @section CSS {
     @await RenderSectionAsync("FormCSS", required: false)


### PR DESCRIPTION
Now that we have removed all the alert uses in `Create` and `Edit` forms (done in #76 and #77), we can get rid of the use case in the layout and delete the now unused markup that was used to display an alert to the side of the form.

This is the final step of the layout cleanup process and thus closes #75 