### PR TITLE
Fix Result Create cancel navigation

### DIFF
--- a/ConselvaBudget/Areas/Budget/Pages/Results/Create.cshtml
+++ b/ConselvaBudget/Areas/Budget/Pages/Results/Create.cshtml
@@ -27,5 +27,9 @@
 </div>
 <div class="col-12">
     <input class="btn btn-primary" type="submit" value="Create">
-    <a class="btn btn-secondary" asp-page="/Projects/Manage" asp-route-id="@Request.Query["projectId"]">Cancel</a>
+    <a class="btn btn-secondary"
+       asp-page="/Projects/Manage"
+       asp-route-id="@Request.Query["project"]">
+        Cancel
+    </a>
 </div>


### PR DESCRIPTION
Fixes an issue where the user would be redirected to a non-existing page when cancelling the Result creation form.

The problem was introduced when the query parameter that contains the current page Project ID was changed from `projectId` to `project`. This parameter is needed to create a link to the appropriate Project Budget page to go "back" to.

This PR fixes the query parameter name to correctly extract the current project the Result is being created to, so the user returns to the correct Project Budget page.