### PR TITLE
Fix Reports area name in navbar

### DIFF
--- a/ConselvaBudget/Resources/Resources.SharedResource.en.resx
+++ b/ConselvaBudget/Resources/Resources.SharedResource.en.resx
@@ -126,7 +126,7 @@
     <comment>Area name</comment>
   </data>
   <data name="AREA_REPORTS" xml:space="preserve">
-    <value>Reporting</value>
+    <value>Reports</value>
     <comment>Area name</comment>
   </data>
   <data name="AREA_SPENDING" xml:space="preserve">


### PR DESCRIPTION
Fixes the navigation bar to use the new area name.