### PR TITLE
Add completed but unpaid requests

### DIFF
--- a/ConselvaBudget/Areas/Spending/Pages/Requests/Index.cshtml
+++ b/ConselvaBudget/Areas/Spending/Pages/Requests/Index.cshtml
@@ -309,6 +309,84 @@ else
 
 <p><a class="btn btn-success"><i class="bi bi-check2-circle"></i> @Localizer["BUTTON_COMPLETED_REQUESTS"]</a></p>
 
+@if (Model.CompletedButUnpaidRequests.Count > 0)
+{
+    <h3>@Localizer["TITLE_COMPLETED_UNPAID_REQUESTS"]</h3>
+    <div class="alert alert-warning" role="alert">
+        <p class="mb-0"><i class="bi bi-exclamation-circle"></i> @Localizer["TITLE_COMPLETED_UNPAID_REQUESTS_NOTICE"]</p>
+    </div>
+
+    <table class="table table-bordered table-striped caption-top">
+        <caption>@Localizer["TITLE_COMPLETED_UNPAID_REQUESTS"]</caption>
+        <thead>
+            <tr>
+                <th>
+                    @Html.DisplayNameFor(model => model.CompletedButUnpaidRequests[0].Id)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.CompletedButUnpaidRequests[0].Description)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.CompletedButUnpaidRequests[0].Activity.Result.Project)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.CompletedButUnpaidRequests[0].Activity)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.CompletedButUnpaidRequests[0].CreatedDate)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.CompletedButUnpaidRequests[0].ModifiedDate)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.CompletedButUnpaidRequests[0].IsPaid)
+                </th>
+                <th style="width: 1px; white-space:nowrap;"></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in Model.CompletedButUnpaidRequests)
+            {
+                <tr>
+                    <td class="align-middle">
+                        @Html.DisplayFor(modelItem => item.Id)
+                    </td>
+                    <td class="align-middle">
+                        @Html.DisplayFor(modelItem => item.Description)
+                    </td>
+                    <td class="align-middle">
+                        @Html.DisplayFor(modelItem => item.Activity.Result.Project.Name)
+                    </td>
+                    <td class="align-middle">
+                        @Html.DisplayFor(modelItem => item.Activity.Code)
+                    </td>
+                    <td class="align-middle">
+                        @Html.DisplayFor(modelItem => item.CreatedDate)
+                    </td>
+                    <td class="align-middle">
+                        @Html.DisplayFor(modelItem => item.ModifiedDate)
+                    </td>
+                    <td class="align-middle">
+                        @if (item.IsPaid)
+                        {
+                            <span class="badge text-bg-success"><i class="bi bi-check-lg"></i></span>
+                        }
+                        else
+                        {
+                            <span class="badge text-bg-secondary"><i class="bi bi-hourglass"></i></span>
+                        }
+                    </td>
+                    <td class="align-middle">
+                        <table-buttons>
+                            <details-button asp-page="Details" asp-route-id="@item.Id"></details-button>
+                        </table-buttons>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
 @if (Model.SpendingRequests.Where(r => r.Status == Models.RequestStatus.Completed).Any())
 {
     <table class="table table-bordered table-striped caption-top">

--- a/ConselvaBudget/Areas/Spending/Pages/Requests/Index.cshtml.cs
+++ b/ConselvaBudget/Areas/Spending/Pages/Requests/Index.cshtml.cs
@@ -20,6 +20,8 @@ namespace ConselvaBudget.Areas.Spending.Pages.Requests
 
         public IList<Request> SpendingRequests { get; set; } = default!;
 
+        public IList<Request> CompletedButUnpaidRequests { get; set; } = default!;
+
         public async Task OnGetAsync()
         {
             var requests = _context.Requests
@@ -40,6 +42,10 @@ namespace ConselvaBudget.Areas.Spending.Pages.Requests
                 .Where(r => r.CreatedDate >= cutOffDate)
                 .OrderByDescending(r => r.CreatedDate)
                 .ToListAsync();
+
+            CompletedButUnpaidRequests = SpendingRequests
+                .Where(r => r.IsPaid == false && r.Status == RequestStatus.Completed)
+                .ToList();
         }
     }
 }

--- a/ConselvaBudget/Resources/Areas.Spending.Pages.Requests.Index.en.resx
+++ b/ConselvaBudget/Resources/Areas.Spending.Pages.Requests.Index.en.resx
@@ -160,6 +160,14 @@
     <value>Completed requests</value>
     <comment>Title for Status Completed</comment>
   </data>
+  <data name="TITLE_COMPLETED_UNPAID_REQUESTS" xml:space="preserve">
+    <value>Completed unpaid requests</value>
+    <comment>Title for the section that may show completed but unpaid requests</comment>
+  </data>
+  <data name="TITLE_COMPLETED_UNPAID_REQUESTS_NOTICE" xml:space="preserve">
+    <value>The following requests are marked as completed, but they are still unpaid.</value>
+    <comment>Explainer of the completed but unpaid table</comment>
+  </data>
   <data name="TITLE_CREATED_REQUESTS" xml:space="preserve">
     <value>Created requests</value>
     <comment>Title for Status Created</comment>

--- a/ConselvaBudget/Resources/Areas.Spending.Pages.Requests.Index.es.resx
+++ b/ConselvaBudget/Resources/Areas.Spending.Pages.Requests.Index.es.resx
@@ -160,6 +160,14 @@
     <value>Solicitudes completadas</value>
     <comment>Title for Status Completed</comment>
   </data>
+  <data name="TITLE_COMPLETED_UNPAID_REQUESTS" xml:space="preserve">
+    <value>Solicitades completadas sin pagar</value>
+    <comment>Title for the section that may show completed but unpaid requests</comment>
+  </data>
+  <data name="TITLE_COMPLETED_UNPAID_REQUESTS_NOTICE" xml:space="preserve">
+    <value>Las siguientes solicitudes están marcadas como completadas, pero aún no se han pagado.</value>
+    <comment>Explainer of the completed but unpaid table</comment>
+  </data>
   <data name="TITLE_CREATED_REQUESTS" xml:space="preserve">
     <value>Solicitudes creadas</value>
     <comment>Title for Status Created</comment>


### PR DESCRIPTION
Adds a table if there are completed but unpaid requests.

- Adds a new property to the Request index view model that contains only the completed and unpaid requests (already filtered by the las N days).
- Adds a table if this new property contains items.
- Adds the required localization strings for this new table.

In combination with the work made in #69 of limiting the number of Requests returned from the database, this closes #92 